### PR TITLE
Communicate test case item responsible for failure

### DIFF
--- a/tests/vse_sync_pp/analyzers/test_analyzer.py
+++ b/tests/vse_sync_pp/analyzers/test_analyzer.py
@@ -171,9 +171,10 @@ class AnalyzerTestBuilder(type):
     def make_test_result(constructor, fqname, expect):
         """Make a function testing analyzer test result and analysis"""
         # pylint: disable=too-many-arguments
-        @params(*expect)
-        def method(self, dct):
+        @params(*enumerate(expect))
+        def method(self, idx, dct):
             """Test analyzer test result and analysis"""
+            msg = f'(item {idx} in `expect`)'
             requirements = dct['requirements']
             parameters = dct['parameters']
             rows = dct['rows']
@@ -183,13 +184,13 @@ class AnalyzerTestBuilder(type):
             config = Config(None, requirements, parameters)
             analyzer = constructor(config)
             analyzer.collect(*rows)
-            self.assertEqual(analyzer.result, result)
-            self.assertEqual(analyzer.reason, reason)
-            self.assertEqual(analyzer.analysis, analysis)
-            with self.assertRaises(CollectionIsClosed):
+            self.assertEqual(analyzer.result, result, msg=msg)
+            self.assertEqual(analyzer.reason, reason, msg=msg)
+            self.assertEqual(analyzer.analysis, analysis, msg=msg)
+            with self.assertRaises(CollectionIsClosed, msg=msg):
                 analyzer.collect(*rows)
-            self.assertEqual(analyzer.result, result)
-            self.assertEqual(analyzer.reason, reason)
-            self.assertEqual(analyzer.analysis, analysis)
+            self.assertEqual(analyzer.result, result, msg=msg)
+            self.assertEqual(analyzer.reason, reason, msg=msg)
+            self.assertEqual(analyzer.analysis, analysis, msg=msg)
         method.__doc__ = f'Test {fqname} analyzer test result and analysis'
         return method

--- a/tests/vse_sync_pp/analyzers/test_ts2phc.py
+++ b/tests/vse_sync_pp/analyzers/test_ts2phc.py
@@ -159,7 +159,7 @@ class TestTimeErrorAnalyzer(TestCase, metaclass=AnalyzerTestBuilder):
                 # oops, missing sample
                 TERR(Decimal(5), 0, 's2'),
             ),
-            'result': False,
+            'result': True,
             'reason': "short test samples",
             'analysis': {
                 'duration': Decimal(4),


### PR DESCRIPTION
```
======================================================================
FAIL: test_result:6
5, {'requirements': 'G.8272/PRTC-A', 'parameters': {'time-error-limit/%': 100,  (tests.vse_sync_pp.analyzers.test_ts2phc.TestTimeErrorAnalyzer.test_result:6
5, {'requirements': 'G.8272/PRTC-A', 'parameters': {'time-error-limit/%': 100, )
Test vse_sync_pp.analyzers.ts2phc.TimeErrorAnalyzer analyzer test result and analysis
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dspence/vse-sync-pp.git/tests/vse_sync_pp/analyzers/test_analyzer.py", line 187, in method
    self.assertEqual(analyzer.result, result, msg=msg)
AssertionError: False != True : (item 5 in `expect`)
```