### PR TITLE
phc2sys parser: Accept optional positive or negative sign in frequency

### DIFF
--- a/src/vse_sync_pp/parsers/phc2sys.py
+++ b/src/vse_sync_pp/parsers/phc2sys.py
@@ -24,7 +24,7 @@ class TimeErrorParser(Parser):
             r'(-?[0-9]+)', # time error
             r'(\S+)', # state
             r'freq\s*',
-            r'(\+?[0-9]+)', # frequency error
+            r'([-+]?[0-9]+)', # frequency error
             r'delay\s*',
             r'(-?[0-9]+)' + # delay
             r'\s*.*$',

--- a/tests/vse_sync_pp/parsers/test_phc2sys.py
+++ b/tests/vse_sync_pp/parsers/test_phc2sys.py
@@ -24,7 +24,16 @@ class TestTimeErrorParser(TestCase, metaclass=ParserTestBuilder):
         (
             'phc2sys[847916.839]: '
             'CLOCK_REALTIME phc offset          4 s2 freq      +639 delay    102',
-            (Decimal(847916.839), 4, 's2', 102),
+            (Decimal('847916.839'), 4, 's2', 102),
+        ),
+        (   'phc2sys[681011.839]: [ptp4l.0.config] '
+            'CLOCK_REALTIME phc offset         8 s2 freq   -6339 delay    502',
+            (Decimal('681011.839'), 8, 's2', 502),
+        ),
+        (
+            'phc2sys[847916.839]: '
+            'CLOCK_REALTIME phc offset          4 s2 freq      -639 delay    102',
+            (Decimal('847916.839'), 4, 's2', 102),
         ),
     )
     reject = ()
@@ -41,7 +50,7 @@ class TestTimeErrorParser(TestCase, metaclass=ParserTestBuilder):
             'CLOCK_REALTIME phc offset          0 s2 freq      +639 delay    102',
             'baz',
             'phc2sys[847916.839]: '
-            'CLOCK_REALTIME phc offset          4 s2 freq      +639 delay    102',
+            'CLOCK_REALTIME phc offset          4 s2 freq      -639 delay    102',
         )),
         (
             (Decimal('847914.839'),  1, 's2', 102),


### PR DESCRIPTION
- parser to accept frequencies which come with a explicit positive or negative sign
- update phc2sys unit tests