### PR TITLE
Parser: accept different configuration file names

### DIFF
--- a/src/vse_sync_pp/parsers/phc2sys.py
+++ b/src/vse_sync_pp/parsers/phc2sys.py
@@ -19,7 +19,7 @@ class TimeErrorParser(Parser):
         return r'\s'.join((
             r'^phc2sys' +
             r'\[([1-9][0-9]*\.[0-9]{3})\]:'+  # timestamp
-            r'(?:\s\[ptp4l\.0\..*\])?',
+            r'(?:\s\[ptp4l\.\d\..*\])?',  # configuration file name
             r'CLOCK_REALTIME phc offset\s*',
             r'(-?[0-9]+)', # time error
             r'(\S+)', # state

--- a/src/vse_sync_pp/parsers/ts2phc.py
+++ b/src/vse_sync_pp/parsers/ts2phc.py
@@ -22,7 +22,7 @@ class TimeErrorParser(Parser):
         return r''.join((
             r'^ts2phc' +
             r'\[([1-9][0-9]*\.[0-9]{3})\]:', # timestamp
-            r'(?:\s\[ts2phc\.0\..*\])?',
+            r'(?:\s\[ts2phc\.\d\..*\])?',  # configuration file name
             fr'\s({interface})' if interface else r'\s(\S+)', # interface
             r'\smaster offset\s*',
             r'\s(-?[0-9]+)', # time error

--- a/tests/vse_sync_pp/parsers/test_phc2sys.py
+++ b/tests/vse_sync_pp/parsers/test_phc2sys.py
@@ -30,6 +30,10 @@ class TestTimeErrorParser(TestCase, metaclass=ParserTestBuilder):
             'CLOCK_REALTIME phc offset         8 s2 freq   -6339 delay    502',
             (Decimal('681011.839'), 8, 's2', 502),
         ),
+        (   'phc2sys[681012.839]: [ptp4l.1.config] '
+            'CLOCK_REALTIME phc offset         8 s2 freq   -6339 delay    502',
+            (Decimal('681012.839'), 8, 's2', 502),
+        ),
         (
             'phc2sys[847916.839]: '
             'CLOCK_REALTIME phc offset          4 s2 freq      -639 delay    102',

--- a/tests/vse_sync_pp/parsers/test_ts2phc.py
+++ b/tests/vse_sync_pp/parsers/test_ts2phc.py
@@ -21,6 +21,10 @@ class TestTimeErrorParser(TestCase, metaclass=ParserTestBuilder):
             'ens7f1 master offset          0 s2 freq      -0',
             (Decimal('681011.839'), 'ens7f1', 0, 's2'),
         ),
+        (   'ts2phc[681011.839]: [ts2phc.2.config] '
+            'ens7f1 master offset          0 s2 freq      -0',
+            (Decimal('681011.839'), 'ens7f1', 0, 's2'),
+        ),
         (   'ts2phc[681011.839]: '
             'ens7f1 master offset          0 s2 freq      -0',
             (Decimal('681011.839'), 'ens7f1', 0, 's2'),


### PR DESCRIPTION
When using more than one configuration, we may see lines in the logs referencing config file names like ts2phc.1.config or ptp4l.2.config. This commit updates the phc2sys and ts2phc parsers to support them.