### PR TITLE
accept relative timestamps from canonical format

### DIFF
--- a/src/vse_sync_pp/parsers/parser.py
+++ b/src/vse_sync_pp/parsers/parser.py
@@ -93,7 +93,7 @@ class Parser():
             if parsed is not None:
                 if relative:
                     tzero, parsed = relative_timestamp(parsed, tzero)
-            yield parsed
+                yield parsed
     def canonical(self, file, relative=False):
         """Parse canonical data from `file` object.
 
@@ -111,4 +111,4 @@ class Parser():
             if parsed is not None:
                 if relative:
                     tzero, parsed = relative_timestamp(parsed, tzero)
-            yield parsed
+                yield parsed


### PR DESCRIPTION
This PR  add the capability to calculate relative timestamps when data input comes in canonical format. To be used for normalizing the timescales for the x-axis for plotting the timeseries of graphs.