### PR TITLE
add failure missing test samples

### DIFF
--- a/src/vse_sync_pp/analyzers/analyzer.py
+++ b/src/vse_sync_pp/analyzers/analyzer.py
@@ -144,6 +144,13 @@ class Analyzer():
         # relative time
         return dec
 
+    @staticmethod
+    def _check_missing_samples(data, result, reason):
+        if reason is None:
+            if len(data.timestamp.diff().astype(float).round(0).tail(-1).unique()) > 1:
+                return (False, "missing test samples")
+        return result, reason
+
     @property
     def result(self):
         """The boolean result from this analyzer's test of the collected data"""

--- a/src/vse_sync_pp/analyzers/phc2sys.py
+++ b/src/vse_sync_pp/analyzers/phc2sys.py
@@ -13,6 +13,9 @@ class TimeErrorAnalyzer(TimeErrorAnalyzerBase):
     parser = id_
     locked = frozenset({'s2'})
 
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))
+
 
 class TimeDeviationAnalyzer(TimeDeviationAnalyzerBase):
     """Analyze time deviation"""
@@ -20,9 +23,15 @@ class TimeDeviationAnalyzer(TimeDeviationAnalyzerBase):
     parser = 'phc2sys/time-error'
     locked = frozenset({'s2'})
 
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))
+
 
 class MaxTimeIntervalErrorAnalyzer(MaxTimeIntervalErrorAnalyzerBase):
     """Analyze max time interval error"""
     id_ = 'phc2sys/mtie'
     parser = 'phc2sys/time-error'
     locked = frozenset({'s2'})
+
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))

--- a/src/vse_sync_pp/analyzers/ts2phc.py
+++ b/src/vse_sync_pp/analyzers/ts2phc.py
@@ -12,6 +12,9 @@ class TimeErrorAnalyzer(TimeErrorAnalyzerBase):
     parser = id_
     locked = frozenset({'s2'})
 
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))
+
 
 class TimeDeviationAnalyzer(TimeDeviationAnalyzerBase):
     """Analyze time deviation"""
@@ -19,9 +22,15 @@ class TimeDeviationAnalyzer(TimeDeviationAnalyzerBase):
     parser = 'ts2phc/time-error'
     locked = frozenset({'s2'})
 
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))
+
 
 class MaxTimeIntervalErrorAnalyzer(MaxTimeIntervalErrorAnalyzerBase):
     """Analyze max time interval error"""
     id_ = 'ts2phc/mtie'
     parser = 'ts2phc/time-error'
     locked = frozenset({'s2'})
+
+    def test(self, data):
+        return self._check_missing_samples(data, *super().test(data))

--- a/tests/vse_sync_pp/analyzers/test_phc2sys.py
+++ b/tests/vse_sync_pp/analyzers/test_phc2sys.py
@@ -193,6 +193,38 @@ class TestTimeErrorAnalyzer(TestCase, metaclass=AnalyzerTestBuilder):
                 'min-test-duration/s': 4,
             },
             'rows': (
+                TERR(Decimal(0), 0, 's2', 620),
+                TERR(Decimal(1), 0, 's2', 620),
+                TERR(Decimal(2), 0, 's2', 620),
+                TERR(Decimal(3), 0, 's2', 620),
+                # oops, missing sample
+                TERR(Decimal(5), 0, 's2', 620),
+                TERR(Decimal(6), 0, 's2', 620),
+            ),
+            'result': False,
+            'reason': "missing test samples",
+            'timestamp': Decimal(1),
+            'duration': Decimal(5),
+            'analysis': {
+                'terror': {
+                    'units': 'ns',
+                    'min': 0,
+                    'max': 0,
+                    'range': 0,
+                    'mean': 0,
+                    'stddev': 0,
+                    'variance': 0,
+                },
+            },
+        },
+        {
+            'requirements': 'workload/RAN',
+            'parameters': {
+                'time-error-limit/%': 100,
+                'transient-period/s': 1,
+                'min-test-duration/s': 4,
+            },
+            'rows': (
                 TERR(Decimal(0), 0, 's1', 620),
                 TERR(Decimal(1), 0, 's2', 620),
                 TERR(Decimal(2), 0, 's2', 620),

--- a/tests/vse_sync_pp/analyzers/test_ts2phc.py
+++ b/tests/vse_sync_pp/analyzers/test_ts2phc.py
@@ -193,6 +193,38 @@ class TestTimeErrorAnalyzer(TestCase, metaclass=AnalyzerTestBuilder):
                 'min-test-duration/s': 4,
             },
             'rows': (
+                TERR(Decimal(0), 0, 's2'),
+                TERR(Decimal(1), 0, 's2'),
+                TERR(Decimal(2), 0, 's2'),
+                TERR(Decimal(3), 0, 's2'),
+                # oops, missing sample
+                TERR(Decimal(5), 0, 's2'),
+                TERR(Decimal(6), 0, 's2'),
+            ),
+            'result': False,
+            'reason': "missing test samples",
+            'timestamp': Decimal(1),
+            'duration': Decimal(5),
+            'analysis': {
+                'terror': {
+                    'units': 'ns',
+                    'min': 0,
+                    'max': 0,
+                    'range': 0,
+                    'mean': 0,
+                    'stddev': 0,
+                    'variance': 0,
+                },
+            },
+        },
+        {
+            'requirements': 'G.8272/PRTC-A',
+            'parameters': {
+                'time-error-limit/%': 100,
+                'transient-period/s': 1,
+                'min-test-duration/s': 4,
+            },
+            'rows': (
                 TERR(Decimal(0), 0, 's1'),
                 TERR(Decimal(1), 0, 's2'),
                 TERR(Decimal(2), 0, 's2'),


### PR DESCRIPTION
This PR adds new class of test result failure where there is a sufficient amount of test samples to compute the intented metric but some samples were lost during the data gathering (e.g., in the case of ts2phc NMEA sentences dont arrive to E810 CVL).
We want to report a failure stating `missing test samples` and produce the plot (to aproximately have an idea instants where data was missing) and get the analysis of the data we could capture if there are more than mininimal set of samples.